### PR TITLE
Fix decimal input bug in potion calculators

### DIFF
--- a/builder-potion.html
+++ b/builder-potion.html
@@ -59,48 +59,47 @@
                 <form id="builderPotionForm" class="form card card--content" data-tab-content="potion">
                     <div class="form__group">
                         <label for="builder-days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="builder-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="builder-days" name="days" min="0" step="1" value="0">
                     </div>
                     <div class="form__group">
                         <label for="builder-hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="builder-hours" name="hours" min="0" max="23"
+                        <input type="number" class="form__input" id="builder-hours" name="hours" min="0" step="1" max="23"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="builder-minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" max="59"
+                        <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" step="1" max="59"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="builder-potions" class="form__label">Builder Potions</label>
-                        <input type="number" class="form__input" id="builder-potions" name="potions" min="0" value="0">
+                        <input type="number" class="form__input" id="builder-potions" name="potions" min="0" step="1" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="builderBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
                     <div class="form__group">
                         <label for="builder-boost-hours" class="form__label">Boost Hours Left</label>
-                        <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0"
+                        <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0" step="1"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="builder-boost-minutes" class="form__label">Boost Minutes Left</label>
-                        <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0"
+                        <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0" step="1"
                             max="59" value="0">
                     </div>
                     <div class="form__group">
                         <label for="builder-boost-days" class="form__label">Upgrade Days Left</label>
-                        <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" step="1" value="0">
                     </div>
                     <div class="form__group">
                         <label for="builder-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0"
+                        <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0" step="1"
                             max="23" value="0">
                     </div>
                     <div class="form__group">
                         <label for="builder-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                        <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes"
-                            min="0" max="59" value="0">
+                        <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes" min="0" step="1" max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/pet-potion.html
+++ b/pet-potion.html
@@ -59,46 +59,46 @@
                 <form id="petPotionForm" class="form card card--content" data-tab-content="potion">
                     <div class="form__group">
                         <label for="pet-days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="pet-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="pet-days" name="days" min="0" step="1" value="0">
                     </div>
                     <div class="form__group">
                         <label for="pet-hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="pet-hours" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="pet-hours" name="hours" min="0" step="1" max="23" value="0">
                     </div>
                     <div class="form__group">
                         <label for="pet-minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" max="59"
+                        <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" step="1" max="59"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="pet-potions" class="form__label">Pet Potions</label>
-                        <input type="number" class="form__input" id="pet-potions" name="potions" min="0" value="0">
+                        <input type="number" class="form__input" id="pet-potions" name="potions" min="0" step="1" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="petBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
                     <div class="form__group">
                         <label for="pet-boost-hours" class="form__label">Boost Hours Left</label>
-                        <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0"
+                        <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0" step="1"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="pet-boost-minutes" class="form__label">Boost Minutes Left</label>
-                        <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0"
+                        <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0" step="1"
                             max="59" value="0">
                     </div>
                     <div class="form__group">
                         <label for="pet-boost-days" class="form__label">Upgrade Days Left</label>
-                        <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" step="1" value="0">
                     </div>
                     <div class="form__group">
                         <label for="pet-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0"
+                        <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0" step="1"
                             max="23" value="0">
                     </div>
                     <div class="form__group">
                         <label for="pet-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                        <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0"
+                        <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0" step="1"
                             max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>

--- a/research-potion.html
+++ b/research-potion.html
@@ -59,48 +59,46 @@
                 <form id="researchPotionForm" class="form card card--content" data-tab-content="potion">
                     <div class="form__group">
                         <label for="research-days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="research-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="research-days" name="days" min="0" step="1" value="0">
                     </div>
                     <div class="form__group">
                         <label for="research-hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="research-hours" name="hours" min="0" max="23"
+                        <input type="number" class="form__input" id="research-hours" name="hours" min="0" step="1" max="23"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="research-minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" max="59"
+                        <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" step="1" max="59"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="research-potions" class="form__label">Research Potions</label>
-                        <input type="number" class="form__input" id="research-potions" name="potions" min="0" value="0">
+                        <input type="number" class="form__input" id="research-potions" name="potions" min="0" step="1" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="researchBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
                     <div class="form__group">
                         <label for="research-boost-hours" class="form__label">Boost Hours Left</label>
-                        <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0"
+                        <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0" step="1"
                             value="0">
                     </div>
                     <div class="form__group">
                         <label for="research-boost-minutes" class="form__label">Boost Minutes Left</label>
-                        <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes"
-                            min="0" max="59" value="0">
+                        <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes" min="0" step="1" max="59" value="0">
                     </div>
                     <div class="form__group">
                         <label for="research-boost-days" class="form__label">Upgrade Days Left</label>
-                        <input type="number" class="form__input" id="research-boost-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="research-boost-days" name="days" min="0" step="1" value="0">
                     </div>
                     <div class="form__group">
                         <label for="research-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0"
+                        <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0" step="1"
                             max="23" value="0">
                     </div>
                     <div class="form__group">
                         <label for="research-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                        <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes"
-                            min="0" max="59" value="0">
+                        <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes" min="0" step="1" max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/simple-calc.html
+++ b/simple-calc.html
@@ -55,15 +55,15 @@
                 <form id="simpleCalcForm" class="form card card--content">
                     <div class="form__group">
                         <label for="days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="days" name="days" min="0" step="1" value="0">
                     </div>
                     <div class="form__group">
                         <label for="hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="hours" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="hours" name="hours" min="0" step="1" max="23" value="0">
                     </div>
                     <div class="form__group">
                         <label for="minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="minutes" name="minutes" min="0" max="59" value="0">
+                        <input type="number" class="form__input" id="minutes" name="minutes" min="0" step="1" max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>


### PR DESCRIPTION
## Summary
- disallow decimal values for all numeric fields by adding `step="1"`

## Testing
- `grep -n "<input type=\"number\"" -r *.html | grep -v "step=\"1\""`

------
https://chatgpt.com/codex/tasks/task_e_6840aadc5cd883268ac1914b45dda90d