### PR TITLE
Align duration fields horizontally

### DIFF
--- a/builder-potion.html
+++ b/builder-potion.html
@@ -57,56 +57,42 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="builderPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="builder-days" class="form__label">Days</label>
-                            <input type="number" class="form__input" id="builder-days" name="days" min="0" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="builder-hours" class="form__label">Hours</label>
-                            <input type="number" class="form__input" id="builder-hours" name="hours" min="0" max="23"
-                                value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="builder-minutes" class="form__label">Minutes</label>
-                            <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" max="59"
-                                value="0">
-                        </div>
+                    <div class="form__row form__row--labels">
+                        <label for="builder-days" class="form__label">Days</label>
+                        <label for="builder-hours" class="form__label">Hours</label>
+                        <label for="builder-minutes" class="form__label">Minutes</label>
                     </div>
-                    <div class="form__group">
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="builder-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="builder-hours" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" max="59" value="0">
+                    </div>
+                    <div class="form__row form__row--labels">
                         <label for="builder-potions" class="form__label">Builder Potions</label>
+                    </div>
+                    <div class="form__row form__row--inputs">
                         <input type="number" class="form__input" id="builder-potions" name="potions" min="0" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="builderBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="builder-boost-hours" class="form__label">Boost Hours Left</label>
-                            <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0"
-                                value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="builder-boost-minutes" class="form__label">Boost Minutes Left</label>
-                            <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0"
-                                max="59" value="0">
-                        </div>
+                    <div class="form__row form__row--labels">
+                        <label for="builder-boost-hours" class="form__label">Boost Hours Left</label>
+                        <label for="builder-boost-minutes" class="form__label">Boost Minutes Left</label>
                     </div>
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="builder-boost-days" class="form__label">Upgrade Days Left</label>
-                            <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="builder-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                            <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0"
-                                max="23" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="builder-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                            <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes"
-                                min="0" max="59" value="0">
-                        </div>
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0" value="0">
+                        <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
+                    </div>
+                    <div class="form__row form__row--labels">
+                        <label for="builder-boost-days" class="form__label">Upgrade Days Left</label>
+                        <label for="builder-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                        <label for="builder-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                    </div>
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/builder-potion.html
+++ b/builder-potion.html
@@ -57,19 +57,21 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="builderPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__group">
-                        <label for="builder-days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="builder-days" name="days" min="0" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="builder-hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="builder-hours" name="hours" min="0" max="23"
-                            value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="builder-minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" max="59"
-                            value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="builder-days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="builder-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="builder-hours" name="hours" min="0" max="23"
+                                value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" max="59"
+                                value="0">
+                        </div>
                     </div>
                     <div class="form__group">
                         <label for="builder-potions" class="form__label">Builder Potions</label>
@@ -78,29 +80,33 @@
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="builderBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__group">
-                        <label for="builder-boost-hours" class="form__label">Boost Hours Left</label>
-                        <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0"
-                            value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="builder-boost-hours" class="form__label">Boost Hours Left</label>
+                            <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0"
+                                value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-boost-minutes" class="form__label">Boost Minutes Left</label>
+                            <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0"
+                                max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__group">
-                        <label for="builder-boost-minutes" class="form__label">Boost Minutes Left</label>
-                        <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0"
-                            max="59" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="builder-boost-days" class="form__label">Upgrade Days Left</label>
-                        <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="builder-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0"
-                            max="23" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="builder-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                        <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes"
-                            min="0" max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="builder-boost-days" class="form__label">Upgrade Days Left</label>
+                            <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                            <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0"
+                                max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                            <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes"
+                                min="0" max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/builder-potion.html
+++ b/builder-potion.html
@@ -57,42 +57,52 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="builderPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__row form__row--labels">
-                        <label for="builder-days" class="form__label">Days</label>
-                        <label for="builder-hours" class="form__label">Hours</label>
-                        <label for="builder-minutes" class="form__label">Minutes</label>
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="builder-days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="builder-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="builder-hours" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="builder-days" name="days" min="0" value="0">
-                        <input type="number" class="form__input" id="builder-hours" name="hours" min="0" max="23" value="0">
-                        <input type="number" class="form__input" id="builder-minutes" name="minutes" min="0" max="59" value="0">
-                    </div>
-                    <div class="form__row form__row--labels">
-                        <label for="builder-potions" class="form__label">Builder Potions</label>
-                    </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="builder-potions" name="potions" min="0" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="builder-potions" class="form__label">Builder Potions</label>
+                            <input type="number" class="form__input" id="builder-potions" name="potions" min="0" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="builderBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__row form__row--labels">
-                        <label for="builder-boost-hours" class="form__label">Boost Hours Left</label>
-                        <label for="builder-boost-minutes" class="form__label">Boost Minutes Left</label>
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="builder-boost-hours" class="form__label">Boost Hours Left</label>
+                            <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-boost-minutes" class="form__label">Boost Minutes Left</label>
+                            <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="builder-boost-hours" name="boost_hours" min="0" value="0">
-                        <input type="number" class="form__input" id="builder-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
-                    </div>
-                    <div class="form__row form__row--labels">
-                        <label for="builder-boost-days" class="form__label">Upgrade Days Left</label>
-                        <label for="builder-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <label for="builder-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                    </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" value="0">
-                        <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
-                        <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="builder-boost-days" class="form__label">Upgrade Days Left</label>
+                            <input type="number" class="form__input" id="builder-boost-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                            <input type="number" class="form__input" id="builder-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="builder-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                            <input type="number" class="form__input" id="builder-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/css/style.css
+++ b/css/style.css
@@ -312,7 +312,9 @@ body {
     flex-direction: column;
     gap: 0.35rem;
     align-items: center;
-    width: 80px;
+    min-width: 80px;
+    max-width: 120px;
+    flex: 1 1 80px;
 }
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -306,6 +306,16 @@ body {
     gap: 0.35rem;
 }
 
+.form__row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.form__row > .form__group {
+    flex: 1;
+}
+
 .form__label {
     font-size: 1.01rem;
     font-weight: 600;

--- a/css/style.css
+++ b/css/style.css
@@ -323,7 +323,10 @@ body {
     letter-spacing: 0.01em;
     margin-bottom: 1px;
     text-align: center;
-    display: block;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    min-height: 3.6rem;
 }
 
 .form__input {

--- a/css/style.css
+++ b/css/style.css
@@ -321,7 +321,7 @@ body {
 
 .form__row--inputs > .form__input {
     flex: none;
-    width: 64px;
+    width: 56px;
     text-align: center;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -300,11 +300,6 @@ body {
     margin: 2.2em auto 0;
 }
 
-.form__group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
 
 .form__row {
     display: flex;
@@ -312,9 +307,24 @@ body {
     gap: 1rem;
 }
 
-.form__row > .form__group {
-    flex: 1;
+.form__row--labels,
+.form__row--inputs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
 }
+
+.form__row--labels > .form__label {
+    flex: 1;
+    text-align: center;
+}
+
+.form__row--inputs > .form__input {
+    flex: none;
+    width: 80px;
+    text-align: center;
+}
+
 
 .form__label {
     font-size: 1.01rem;

--- a/css/style.css
+++ b/css/style.css
@@ -321,7 +321,7 @@ body {
 
 .form__row--inputs > .form__input {
     flex: none;
-    width: 80px;
+    width: 64px;
     text-align: center;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -312,6 +312,7 @@ body {
     flex-direction: column;
     gap: 0.35rem;
     align-items: center;
+    width: 80px;
 }
 
 
@@ -321,6 +322,8 @@ body {
     color: var(--text-secondary);
     letter-spacing: 0.01em;
     margin-bottom: 1px;
+    text-align: center;
+    display: block;
 }
 
 .form__input {

--- a/css/style.css
+++ b/css/style.css
@@ -307,22 +307,11 @@ body {
     gap: 1rem;
 }
 
-.form__row--labels,
-.form__row--inputs {
+.form__group {
     display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-}
-
-.form__row--labels > .form__label {
-    flex: 1;
-    text-align: center;
-}
-
-.form__row--inputs > .form__input {
-    flex: none;
-    width: 56px;
-    text-align: center;
+    flex-direction: column;
+    gap: 0.35rem;
+    align-items: center;
 }
 
 
@@ -345,6 +334,8 @@ body {
     font-weight: 500;
     box-shadow: 0 1.5px 8px 0 rgba(160, 160, 180, 0.07);
     transition: border var(--transition), box-shadow var(--transition), background var(--transition);
+    width: 56px;
+    text-align: center;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/pet-potion.html
+++ b/pet-potion.html
@@ -57,42 +57,52 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="petPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__row form__row--labels">
-                        <label for="pet-days" class="form__label">Days</label>
-                        <label for="pet-hours" class="form__label">Hours</label>
-                        <label for="pet-minutes" class="form__label">Minutes</label>
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="pet-days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="pet-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="pet-hours" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="pet-days" name="days" min="0" value="0">
-                        <input type="number" class="form__input" id="pet-hours" name="hours" min="0" max="23" value="0">
-                        <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" max="59" value="0">
-                    </div>
-                    <div class="form__row form__row--labels">
-                        <label for="pet-potions" class="form__label">Pet Potions</label>
-                    </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="pet-potions" name="potions" min="0" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="pet-potions" class="form__label">Pet Potions</label>
+                            <input type="number" class="form__input" id="pet-potions" name="potions" min="0" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="petBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__row form__row--labels">
-                        <label for="pet-boost-hours" class="form__label">Boost Hours Left</label>
-                        <label for="pet-boost-minutes" class="form__label">Boost Minutes Left</label>
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="pet-boost-hours" class="form__label">Boost Hours Left</label>
+                            <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-boost-minutes" class="form__label">Boost Minutes Left</label>
+                            <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0" value="0">
-                        <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
-                    </div>
-                    <div class="form__row form__row--labels">
-                        <label for="pet-boost-days" class="form__label">Upgrade Days Left</label>
-                        <label for="pet-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <label for="pet-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                    </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" value="0">
-                        <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
-                        <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="pet-boost-days" class="form__label">Upgrade Days Left</label>
+                            <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                            <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                            <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/pet-potion.html
+++ b/pet-potion.html
@@ -57,55 +57,42 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="petPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="pet-days" class="form__label">Days</label>
-                            <input type="number" class="form__input" id="pet-days" name="days" min="0" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="pet-hours" class="form__label">Hours</label>
-                            <input type="number" class="form__input" id="pet-hours" name="hours" min="0" max="23" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="pet-minutes" class="form__label">Minutes</label>
-                            <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" max="59"
-                                value="0">
-                        </div>
+                    <div class="form__row form__row--labels">
+                        <label for="pet-days" class="form__label">Days</label>
+                        <label for="pet-hours" class="form__label">Hours</label>
+                        <label for="pet-minutes" class="form__label">Minutes</label>
                     </div>
-                    <div class="form__group">
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="pet-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="pet-hours" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" max="59" value="0">
+                    </div>
+                    <div class="form__row form__row--labels">
                         <label for="pet-potions" class="form__label">Pet Potions</label>
+                    </div>
+                    <div class="form__row form__row--inputs">
                         <input type="number" class="form__input" id="pet-potions" name="potions" min="0" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="petBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="pet-boost-hours" class="form__label">Boost Hours Left</label>
-                            <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0"
-                                value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="pet-boost-minutes" class="form__label">Boost Minutes Left</label>
-                            <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0"
-                                max="59" value="0">
-                        </div>
+                    <div class="form__row form__row--labels">
+                        <label for="pet-boost-hours" class="form__label">Boost Hours Left</label>
+                        <label for="pet-boost-minutes" class="form__label">Boost Minutes Left</label>
                     </div>
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="pet-boost-days" class="form__label">Upgrade Days Left</label>
-                            <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="pet-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                            <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0"
-                                max="23" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="pet-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                            <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0"
-                                max="59" value="0">
-                        </div>
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0" value="0">
+                        <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
+                    </div>
+                    <div class="form__row form__row--labels">
+                        <label for="pet-boost-days" class="form__label">Upgrade Days Left</label>
+                        <label for="pet-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                        <label for="pet-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                    </div>
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/pet-potion.html
+++ b/pet-potion.html
@@ -57,18 +57,20 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="petPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__group">
-                        <label for="pet-days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="pet-days" name="days" min="0" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="pet-hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="pet-hours" name="hours" min="0" max="23" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="pet-minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" max="59"
-                            value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="pet-days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="pet-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="pet-hours" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="pet-minutes" name="minutes" min="0" max="59"
+                                value="0">
+                        </div>
                     </div>
                     <div class="form__group">
                         <label for="pet-potions" class="form__label">Pet Potions</label>
@@ -77,29 +79,33 @@
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="petBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__group">
-                        <label for="pet-boost-hours" class="form__label">Boost Hours Left</label>
-                        <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0"
-                            value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="pet-boost-hours" class="form__label">Boost Hours Left</label>
+                            <input type="number" class="form__input" id="pet-boost-hours" name="boost_hours" min="0"
+                                value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-boost-minutes" class="form__label">Boost Minutes Left</label>
+                            <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0"
+                                max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__group">
-                        <label for="pet-boost-minutes" class="form__label">Boost Minutes Left</label>
-                        <input type="number" class="form__input" id="pet-boost-minutes" name="boost_minutes" min="0"
-                            max="59" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="pet-boost-days" class="form__label">Upgrade Days Left</label>
-                        <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="pet-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0"
-                            max="23" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="pet-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                        <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0"
-                            max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="pet-boost-days" class="form__label">Upgrade Days Left</label>
+                            <input type="number" class="form__input" id="pet-boost-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                            <input type="number" class="form__input" id="pet-boost-hours-upgrade" name="hours" min="0"
+                                max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="pet-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                            <input type="number" class="form__input" id="pet-boost-minutes-upgrade" name="minutes" min="0"
+                                max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/research-potion.html
+++ b/research-potion.html
@@ -57,19 +57,21 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="researchPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__group">
-                        <label for="research-days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="research-days" name="days" min="0" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="research-hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="research-hours" name="hours" min="0" max="23"
-                            value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="research-minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" max="59"
-                            value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="research-days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="research-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="research-hours" name="hours" min="0" max="23"
+                                value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" max="59"
+                                value="0">
+                        </div>
                     </div>
                     <div class="form__group">
                         <label for="research-potions" class="form__label">Research Potions</label>
@@ -78,29 +80,33 @@
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="researchBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__group">
-                        <label for="research-boost-hours" class="form__label">Boost Hours Left</label>
-                        <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0"
-                            value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="research-boost-hours" class="form__label">Boost Hours Left</label>
+                            <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0"
+                                value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-boost-minutes" class="form__label">Boost Minutes Left</label>
+                            <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes"
+                                min="0" max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__group">
-                        <label for="research-boost-minutes" class="form__label">Boost Minutes Left</label>
-                        <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes"
-                            min="0" max="59" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="research-boost-days" class="form__label">Upgrade Days Left</label>
-                        <input type="number" class="form__input" id="research-boost-days" name="days" min="0" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="research-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0"
-                            max="23" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="research-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                        <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes"
-                            min="0" max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="research-boost-days" class="form__label">Upgrade Days Left</label>
+                            <input type="number" class="form__input" id="research-boost-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                            <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0"
+                                max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                            <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes"
+                                min="0" max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/research-potion.html
+++ b/research-potion.html
@@ -57,42 +57,52 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="researchPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__row form__row--labels">
-                        <label for="research-days" class="form__label">Days</label>
-                        <label for="research-hours" class="form__label">Hours</label>
-                        <label for="research-minutes" class="form__label">Minutes</label>
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="research-days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="research-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="research-hours" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="research-days" name="days" min="0" value="0">
-                        <input type="number" class="form__input" id="research-hours" name="hours" min="0" max="23" value="0">
-                        <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" max="59" value="0">
-                    </div>
-                    <div class="form__row form__row--labels">
-                        <label for="research-potions" class="form__label">Research Potions</label>
-                    </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="research-potions" name="potions" min="0" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="research-potions" class="form__label">Research Potions</label>
+                            <input type="number" class="form__input" id="research-potions" name="potions" min="0" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="researchBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__row form__row--labels">
-                        <label for="research-boost-hours" class="form__label">Boost Hours Left</label>
-                        <label for="research-boost-minutes" class="form__label">Boost Minutes Left</label>
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="research-boost-hours" class="form__label">Boost Hours Left</label>
+                            <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-boost-minutes" class="form__label">Boost Minutes Left</label>
+                            <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0" value="0">
-                        <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
-                    </div>
-                    <div class="form__row form__row--labels">
-                        <label for="research-boost-days" class="form__label">Upgrade Days Left</label>
-                        <label for="research-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                        <label for="research-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                    </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="research-boost-days" name="days" min="0" value="0">
-                        <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
-                        <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="research-boost-days" class="form__label">Upgrade Days Left</label>
+                            <input type="number" class="form__input" id="research-boost-days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                            <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="research-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                            <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/research-potion.html
+++ b/research-potion.html
@@ -57,56 +57,42 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="researchPotionForm" class="form card card--content" data-tab-content="potion">
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="research-days" class="form__label">Days</label>
-                            <input type="number" class="form__input" id="research-days" name="days" min="0" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="research-hours" class="form__label">Hours</label>
-                            <input type="number" class="form__input" id="research-hours" name="hours" min="0" max="23"
-                                value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="research-minutes" class="form__label">Minutes</label>
-                            <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" max="59"
-                                value="0">
-                        </div>
+                    <div class="form__row form__row--labels">
+                        <label for="research-days" class="form__label">Days</label>
+                        <label for="research-hours" class="form__label">Hours</label>
+                        <label for="research-minutes" class="form__label">Minutes</label>
                     </div>
-                    <div class="form__group">
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="research-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="research-hours" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="research-minutes" name="minutes" min="0" max="59" value="0">
+                    </div>
+                    <div class="form__row form__row--labels">
                         <label for="research-potions" class="form__label">Research Potions</label>
+                    </div>
+                    <div class="form__row form__row--inputs">
                         <input type="number" class="form__input" id="research-potions" name="potions" min="0" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>
                 <form id="researchBoostForm" class="form card card--content form--hidden" data-tab-content="boost">
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="research-boost-hours" class="form__label">Boost Hours Left</label>
-                            <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0"
-                                value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="research-boost-minutes" class="form__label">Boost Minutes Left</label>
-                            <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes"
-                                min="0" max="59" value="0">
-                        </div>
+                    <div class="form__row form__row--labels">
+                        <label for="research-boost-hours" class="form__label">Boost Hours Left</label>
+                        <label for="research-boost-minutes" class="form__label">Boost Minutes Left</label>
                     </div>
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="research-boost-days" class="form__label">Upgrade Days Left</label>
-                            <input type="number" class="form__input" id="research-boost-days" name="days" min="0" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="research-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
-                            <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0"
-                                max="23" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="research-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
-                            <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes"
-                                min="0" max="59" value="0">
-                        </div>
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="research-boost-hours" name="boost_hours" min="0" value="0">
+                        <input type="number" class="form__input" id="research-boost-minutes" name="boost_minutes" min="0" max="59" value="0">
+                    </div>
+                    <div class="form__row form__row--labels">
+                        <label for="research-boost-days" class="form__label">Upgrade Days Left</label>
+                        <label for="research-boost-hours-upgrade" class="form__label">Upgrade Hours Left</label>
+                        <label for="research-boost-minutes-upgrade" class="form__label">Upgrade Minutes Left</label>
+                    </div>
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="research-boost-days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="research-boost-hours-upgrade" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="research-boost-minutes-upgrade" name="minutes" min="0" max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/simple-calc.html
+++ b/simple-calc.html
@@ -53,15 +53,19 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="simpleCalcForm" class="form card card--content">
-                    <div class="form__row form__row--labels">
-                        <label for="days" class="form__label">Days</label>
-                        <label for="hours" class="form__label">Hours</label>
-                        <label for="minutes" class="form__label">Minutes</label>
-                    </div>
-                    <div class="form__row form__row--inputs">
-                        <input type="number" class="form__input" id="days" name="days" min="0" value="0">
-                        <input type="number" class="form__input" id="hours" name="hours" min="0" max="23" value="0">
-                        <input type="number" class="form__input" id="minutes" name="minutes" min="0" max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="hours" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="minutes" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/simple-calc.html
+++ b/simple-calc.html
@@ -53,19 +53,15 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="simpleCalcForm" class="form card card--content">
-                    <div class="form__row">
-                        <div class="form__group">
-                            <label for="days" class="form__label">Days</label>
-                            <input type="number" class="form__input" id="days" name="days" min="0" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="hours" class="form__label">Hours</label>
-                            <input type="number" class="form__input" id="hours" name="hours" min="0" max="23" value="0">
-                        </div>
-                        <div class="form__group">
-                            <label for="minutes" class="form__label">Minutes</label>
-                            <input type="number" class="form__input" id="minutes" name="minutes" min="0" max="59" value="0">
-                        </div>
+                    <div class="form__row form__row--labels">
+                        <label for="days" class="form__label">Days</label>
+                        <label for="hours" class="form__label">Hours</label>
+                        <label for="minutes" class="form__label">Minutes</label>
+                    </div>
+                    <div class="form__row form__row--inputs">
+                        <input type="number" class="form__input" id="days" name="days" min="0" value="0">
+                        <input type="number" class="form__input" id="hours" name="hours" min="0" max="23" value="0">
+                        <input type="number" class="form__input" id="minutes" name="minutes" min="0" max="59" value="0">
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>

--- a/simple-calc.html
+++ b/simple-calc.html
@@ -53,17 +53,19 @@
         <div class="split-layout">
             <div class="split-layout__left">
                 <form id="simpleCalcForm" class="form card card--content">
-                    <div class="form__group">
-                        <label for="days" class="form__label">Days</label>
-                        <input type="number" class="form__input" id="days" name="days" min="0" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="hours" class="form__label">Hours</label>
-                        <input type="number" class="form__input" id="hours" name="hours" min="0" max="23" value="0">
-                    </div>
-                    <div class="form__group">
-                        <label for="minutes" class="form__label">Minutes</label>
-                        <input type="number" class="form__input" id="minutes" name="minutes" min="0" max="59" value="0">
+                    <div class="form__row">
+                        <div class="form__group">
+                            <label for="days" class="form__label">Days</label>
+                            <input type="number" class="form__input" id="days" name="days" min="0" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="hours" class="form__label">Hours</label>
+                            <input type="number" class="form__input" id="hours" name="hours" min="0" max="23" value="0">
+                        </div>
+                        <div class="form__group">
+                            <label for="minutes" class="form__label">Minutes</label>
+                            <input type="number" class="form__input" id="minutes" name="minutes" min="0" max="59" value="0">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn--primary btn--animated">Calculate</button>
                 </form>


### PR DESCRIPTION
## Summary
- arrange day/hour/minute inputs on a single row for all calculators
- add new `.form__row` CSS class to style the new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d27985fc8326a747c708ba58278a